### PR TITLE
Refactor external soreness

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -560,32 +560,31 @@ This function completely restores a damaged organ to perfect condition.
 		return TRUE
 	return FALSE
 
-//This proc handles all the soreness related logic.
-/obj/item/organ/external/proc/process_soreness()
+/obj/item/organ/external/process_soreness()
 	if(!soreness || damage)
 		return
 	vulnerable = TRUE
 	switch(soreness)
-		if(101 to 200)
+		if(max_soreness / 4 to max_soreness / 2)
 			if(pain <= 20)
 				add_pain(15)
-		if(201 to INFINITY)
+		if(max_soreness / 2 to max_soreness)
 			if(pain <=30)
 				add_pain(25)
 
-	if(owner.life_tick % 10 == 0)	//Don't spam the chat
+	if(prob(5))	//Don't spam the chat
 		switch(soreness)
-			if(1 to 100)
-				to_chat(owner, SPAN_WARNING("Your [name] feels sore."))
-			if(101 to 200)
-				to_chat(owner, SPAN_WARNING("Your [name] throbs with pain."))
-			if(201 to INFINITY)
-				to_chat(owner, SPAN_DANGER("Your [name] hurts very badly!"))
+			if(1 to max_soreness / 4)
+				owner.custom_pain(SPAN_WARNING("Your [name] feels sore."), soreness / 5)
+			if(max_soreness / 4 to max_soreness / 2)
+				owner.custom_pain(SPAN_WARNING("Your [name] throbs with pain."), soreness / 5)
+			if(max_soreness / 2 to max_soreness)
+				owner.custom_pain(SPAN_DANGER("Your [name] hurts very badly!"), soreness / 5)
 
 	soreness = Floor(soreness * 0.98) - 1	//Slower decrease as soreness lowers. Faster if in bed
 	if(owner.buckled && owner.buckled.type == /obj/structure/bed)	//TODO Comfiness
 		soreness -= 2
-	if(soreness <=0)
+	if(soreness <= 0)
 		soreness = 0
 		vulnerable = FALSE
 
@@ -602,7 +601,7 @@ This function completely restores a damaged organ to perfect condition.
 		if(owner.life_tick % soreness_update_accuracy == 0)
 			if(!BP_IS_ROBOTIC(src))
 				if(damage * 10 > soreness)
-					soreness = 10 * damage  //A larger soreness number allows for fine tuning the decrease.
+					soreness = min(10 * damage, max_soreness)
 				process_soreness()
 
 

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -13,10 +13,10 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	brute = round(brute * get_brute_mod(damage_flags), 0.1)
 	burn = round(burn * get_burn_mod(damage_flags), 0.1)
 
-	//Vulnerable (currently sore from recent damages) organs takes more damage.
-	if(vulnerable)
-		brute = round(brute * 1.2, 0.1)
-		burn = round(burn * 1.2, 0.1)
+	//Sore organs take extra damage.
+	if(vulnerable && soreness && damage < soreness * 10)
+		brute = round(brute * 1 + soreness / 100)
+		burn  = round(brute * 1 + soreness / 100)
 
 	if((brute <= 0) && (burn <= 0))
 		return 0

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -14,8 +14,8 @@ var/list/organ_cache = list()
 	// Status tracking.
 	var/status = 0                    // Various status flags (such as robotic)
 	var/vital                         // Lose a vital limb, die immediately.
-	var/vulnerable					  // Indicates if the organ is vulnerable (was recently hurt)
-
+	var/vulnerable                    // Whether or not we're eligible to take extra damage.
+	
 	// Reference data.
 	var/mob/living/carbon/human/owner // Current mob owning the organ.
 	var/datum/dna/dna                 // Original DNA.
@@ -27,6 +27,7 @@ var/list/organ_cache = list()
 	var/max_damage = 30               // Damage cap
 	var/rejecting                     // Is this organ already being rejected?
 	var/soreness = 0				  // Current soreness to the organ
+	var/max_soreness                  // The maximum value of soreness. Defaults to 10 * max_damage.
 
 	var/death_time
 
@@ -61,6 +62,9 @@ var/list/organ_cache = list()
 		min_broken_damage = Floor(max_damage / 2)
 	else
 		max_damage = min_broken_damage * 2
+
+	if(!max_soreness)
+		max_soreness = max_damage * 10
 
 	if(istype(holder))
 		owner = holder
@@ -140,6 +144,9 @@ var/list/organ_cache = list()
 		handle_antibiotics()
 		handle_rejection()
 		handle_germ_effects()
+
+/obj/item/organ/proc/process_soreness()
+	return
 
 /obj/item/organ/proc/is_preserved()
 	if(istype(loc,/obj/item/organ))


### PR DESCRIPTION
- Soreness now has a cap at 10 * the organ's maximum damage.
- Hard numbers are no longer used for determining pain messages, but instead are derived from maximum soreness.
- Use custom pain instead of to chat for pain messages.
- Use prob instead of life tick for pain messages.
- Vulnerability and damage boost has been reworked. Now, once an organ is damaged and then heals, it will take extra damage up to its current soreness level but not past it. The damage boost is now also dependent on an organ's soreness. A multiplier is added based on the current soreness level / 100. Meaning, if you took 20 damage to an organ and then healed, further damage would be multiplied by 1.2x until you reach 20 damage again, at which point the damage boost will stop and you'll accrue further damage/soreness at the normal rate.
- `process_soreness` is now defined in `/obj/item/organ/`.